### PR TITLE
Autopopulation of date fields.

### DIFF
--- a/js/stanford_events_importer.js
+++ b/js/stanford_events_importer.js
@@ -153,9 +153,12 @@
     var AMPM = time.match(/(am|pm)/gi);
 
     // If am/pm is found then look for pm and add 12hrs to the current time.
-    if (AMPM instanceof Array && hours < 12) {
-      if (AMPM[0] == "pm" || AMPM[0] == "PM") {
+    if (AMPM instanceof Array) {
+      if (AMPM[0].toLowerCase() == "pm" && hours <= 11) {
         hours = hours + 12;
+      }
+      if (AMPM[0].toLowerCase() == "am" && hours == 12) {
+        hours = 0;
       }
     }
 

--- a/js/stanford_events_importer.js
+++ b/js/stanford_events_importer.js
@@ -1,0 +1,84 @@
+/**
+ * Tracks the time field in the date and time settings for changes
+ * so that it may autopopulate the 'to' field.
+ */
+
+
+(function($){
+
+  Drupal.behaviors.stanford_date_timepicker = {
+    attach: function (context, settings) {
+
+      $.each($('.start-date-wrapper ', context), function(i, v) {
+        var timefield = $(v).find('input:eq(1)');
+
+
+        timefield.blur(time_blur_handler); // each
+      }); // attach
+
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+
+
+  /**
+   * [time_blur_handler description]
+   * @param  {[type]} e [description]
+   * @return {[type]}   [description]
+   */
+  var time_blur_handler = function(e) {
+
+    var showend = $(this)
+        .closest('.fieldset-wrapper')
+        .find('.form-type-checkbox label:contains("Show End Date")')
+        .siblings('input');
+
+    var checked = showend.attr('checked');
+
+    // If show end date is not checked then die.
+    if (!checked) {
+      return;
+    }
+
+    // Fields and variable Definition.
+    var fields = $(this)
+                 .closest('.fieldset-wrapper')
+                 .find('.end-date-wrapper input');
+    var to_date_field   = fields.eq(0);
+    var to_time_field   = fields.eq(1);
+    var from_date_field = $(this)
+                 .closest('.fieldset-wrapper')
+                 .find('.start-date-wrapper input:eq(0)');
+    var from_date_value = from_date_field.val();
+    var from_time_value = $(this).val();
+
+    if (typeof to_date_field === undefined) {
+      return;
+    }
+
+    if (typeof to_date_field === undefined) {
+      return;
+    }
+
+    if (to_date_field.val().length === 0) {
+      to_date_field.val(from_date_value);
+    }
+
+    var date_object = new Date(from_date_value + " " + from_time_value);
+    date_object.setHours(date_object.getHours() + 1);
+    var hr = date_object.getHours() < 12 ? date_object.getHours() : date_object.getHours() - 12;
+    var min = date_object.getMinutes();
+    if (min < 10) {
+        min = "0" + min;
+    }
+    var ampm = date_object.getHours() < 12 ? "am" : "pm";
+
+    var formatted_date = hr + ":" + min + ampm;
+
+    to_time_field.val(formatted_date);
+
+  };
+
+
+})(jQuery);

--- a/js/stanford_events_importer.js
+++ b/js/stanford_events_importer.js
@@ -96,7 +96,7 @@
 
     // Set the time field to the new date.
     to_time_field.val(formatted_time);
-    to_time_field.highlight();
+    to_time_field.quiet_highlight();
 
   };
 
@@ -221,11 +221,11 @@
 // Jquery Plugins
 // -----------------------------------------------------------------------------
 
-  if(typeof $.fn.highlight !== "function") {
+  if(typeof $.fn.quiet_highlight !== "function") {
       /**
      * A quick yellow highlight that fades out.
      */
-    $.fn.highlight = function() {
+    $.fn.quiet_highlight = function() {
 
       $(this).each(function () {
           var el = $(this);

--- a/js/stanford_events_importer.js
+++ b/js/stanford_events_importer.js
@@ -47,8 +47,9 @@
     var checked = showend.attr('checked');
 
     // If show end date is not checked then die.
-    if (!checked) { return; }
-
+    if (!checked) {
+      return;
+    }
 
     // Fields and variable definitions oh my!
     var fields = $(this)
@@ -235,22 +236,31 @@
 
       $(this).each(function () {
           var el = $(this);
-          $("<div/>")
-          .width(el.outerWidth())
-          .height(el.outerHeight())
-          .css({
-              "position": "absolute",
-              "left": el.offset().left,
-              "top": el.offset().top,
-              "background-color": "#ffff99",
-              "opacity": ".7",
-              "z-index": "9999999"
-          }).appendTo('body').fadeOut(1000).queue(function () { $(this).remove(); });
+      el.css({position:"relative",zIndex:'1',background:"transparent"});
+      el.parent().css({position:"relative"});
+
+      var div = $("<div/>")
+      .addClass('su-highlighter')
+      .width(el.outerWidth())
+      .height(el.outerHeight())
+      .css({
+          "position": "absolute",
+          "left": 0,
+          "top": 20,
+          "background-color": "#ffff99",
+          "opacity": ".7",
+          "z-index": "0"
       });
 
-    };
+      $(this).before(div);
+      div.fadeOut(1000)
+      .queue(function () {
+        $(this).remove();
+        el.css({background:"#FFFFFF"});
+      });
 
-  }
-
+    });
+  };
+}
 
 })(jQuery);

--- a/js/stanford_events_importer.js
+++ b/js/stanford_events_importer.js
@@ -153,7 +153,7 @@
     var AMPM = time.match(/(am|pm)/gi);
 
     // If am/pm is found then look for pm and add 12hrs to the current time.
-    if (AMPM instanceof Array) {
+    if (AMPM instanceof Array && hours < 12) {
       if (AMPM[0] == "pm" || AMPM[0] == "PM") {
         hours = hours + 12;
       }
@@ -192,11 +192,14 @@
     var formatted = php_format;
 
     // Define date parts as string with preceeding 0s by default.
-    var hr_twentyfour = date_object.getHours() < 12 ? "0" + date_object.getHours().toString() : date_object.getHours();
-    var hr_twelve = (hr_twentyfour - 12) < 12 ? "0" + (hr_twentyfour - 12) : 12;
+    var ampm = date_object.getHours() < 12 ? "am" : "pm";
+    var hr_twentyfour = date_object.getHours() < 10 ? "0" + date_object.getHours().toString() : date_object.getHours().toString();
+    var hr_twelve = hr_twentyfour;
+    if (parseInt(hr_twelve, 10) >= 12) { hr_twelve = hr_twentyfour-12; }
+    if (hr_twelve === 0) { hr_twelve = 12; }
+    hr_twelve = (hr_twelve < 10) ? "0" + hr_twelve : hr_twelve.toString();
     var min = date_object.getMinutes() < 10 ? "0" + date_object.getMinutes().toString() : date_object.getMinutes();
     var sec = date_object.getSeconds() < 10 ? "0" + date_object.getSeconds().toString() : date_object.getSeconds();
-    var ampm = date_object.getHours() < 12 ? "am" : "pm";
 
     // Hours.
     formatted = formatted.replace(/[H]/g, hr_twentyfour);

--- a/js/stanford_events_importer.js
+++ b/js/stanford_events_importer.js
@@ -6,19 +6,23 @@
 
 (function($){
 
+  // Drupal Behaviours
+  // ---------------------------------------------------------------------------
+
+
   Drupal.behaviors.stanford_date_timepicker = {
     attach: function (context, settings) {
 
       $.each($('.start-date-wrapper ', context), function(i, v) {
         var timefield = $(v).find('input:eq(1)');
-
-
-        timefield.blur(time_blur_handler); // each
-      }); // attach
+        timefield.blur(time_blur_handler);
+      });
 
     }
   };
 
+
+  // Handlers and Callbacks
   // ---------------------------------------------------------------------------
 
 
@@ -29,19 +33,18 @@
    */
   var time_blur_handler = function(e) {
 
+    // First find the show end date checkbox and see if it is checked.
     var showend = $(this)
         .closest('.fieldset-wrapper')
         .find('.form-type-checkbox label:contains("Show End Date")')
         .siblings('input');
-
     var checked = showend.attr('checked');
 
     // If show end date is not checked then die.
-    if (!checked) {
-      return;
-    }
+    if (!checked) { return; }
 
-    // Fields and variable Definition.
+
+    // Fields and variable definitions oh my!
     var fields = $(this)
                  .closest('.fieldset-wrapper')
                  .find('.end-date-wrapper input');
@@ -52,33 +55,96 @@
                  .find('.start-date-wrapper input:eq(0)');
     var from_date_value = from_date_field.val();
     var from_time_value = $(this).val();
+    var php_time_format = $(this).data('timeformat');
 
-    if (typeof to_date_field === undefined) {
-      return;
-    }
 
-    if (typeof to_date_field === undefined) {
-      return;
-    }
+    // If we can't find the fields then we must end our journey.
+    if (typeof to_date_field === undefined) { return; }
+    if (typeof to_time_field === undefined) { return; }
 
+    // If the date field is empty populate it.
     if (to_date_field.val().length === 0) {
       to_date_field.val(from_date_value);
     }
 
-    var date_object = new Date(from_date_value + " " + from_time_value);
-    date_object.setHours(date_object.getHours() + 1);
-    var hr = date_object.getHours() < 12 ? date_object.getHours() : date_object.getHours() - 12;
-    var min = date_object.getMinutes();
-    if (min < 10) {
-        min = "0" + min;
-    }
-    var ampm = date_object.getHours() < 12 ? "am" : "pm";
+    // Date conversion needs 24hr format.
+    var from_time_value_twenty_four = stanford_events_importer_time_to_twenty_four(from_time_value);
 
-    var formatted_date = hr + ":" + min + ampm;
+    // Format the new time appropriately.
+    var date_object = new Date(from_date_value + " " + from_time_value_twenty_four);
+    var formatted_time = stanford_events_importer_get_formatted_time(date_object, php_time_format);
 
-    to_time_field.val(formatted_date);
+    // Set the time field to the new date.
+    to_time_field.val(formatted_time);
 
   };
 
+  // Public Functions
+  // ---------------------------------------------------------------------------
+
+
+  function stanford_events_importer_time_to_twenty_four(time) {
+
+    var hours = Number(time.match(/^(\d+)/)[1]);
+    var minutes = Number(time.match(/:(\d+)/)[1]);
+    var seconds = time.match(/:(\d+)/)[2];
+
+    var AMPM = time.match(/(am|pm)/gi);
+    if (AMPM instanceof Array) {
+      if (AMPM[0] == "pm" || APMPM[0] == "PM") {
+        hours = hours + 12;
+      }
+    }
+
+    var sHours = hours.toString();
+    var sMinutes = minutes.toString();
+    if(hours<10) sHours = "0" + sHours;
+    if(minutes<10) sMinutes = "0" + sMinutes;
+
+    var formatted = sHours + ":" + sMinutes;
+    if(typeof seconds === 'string') {
+      formatted += ":" + seconds;
+    }
+
+    return formatted;
+  }
+
+
+  /**
+   * [stanford_events_importer_get_formatted_time description]
+   * @param  {[type]} dateobj    [description]
+   * @param  {[type]} php_format [description]
+   * @return {[type]}            [description]
+   */
+  function stanford_events_importer_get_formatted_time(date_object, php_format) {
+
+    var formatted = php_format;
+
+    date_object.setHours(date_object.getHours() + 1);
+    var hr_twentyfour = date_object.getHours() < 12 ? "0" + date_object.getHours().toString() : date_object.getHours();
+    var hr_twelve = (hr_twentyfour - 12) < 12 ? "0" + (hr_twentyfour - 12) : 12;
+    var min = date_object.getMinutes() < 10 ? "0" + date_object.getMinutes().toString() : date_object.getMinutes();
+    var sec = date_object.getSeconds() < 10 ? "0" + date_object.getSeconds().toString() : date_object.getSeconds();
+    var ampm = date_object.getHours() < 12 ? "am" : "pm";
+
+    // Hours.
+    formatted = formatted.replace(/[H]/g, hr_twentyfour);
+    formatted = formatted.replace(/[h]/g, hr_twelve);
+    formatted = formatted.replace(/[g]/g, Math.round(hr_twelve));
+    formatted = formatted.replace(/[G]/g, Math.round(hr_twentyfour));
+
+    // Minutes.
+    formatted = formatted.replace(/[i]/g, min);
+
+    // Seconds.
+    formatted = formatted.replace(/[s]/g, sec);
+
+    // Am/Pm.
+    formatted = formatted.replace(/[a]/g, ampm);
+    formatted = formatted.replace(/[A]/g, ampm.toUpperCase());
+    return formatted;
+  }
+
 
 })(jQuery);
+

--- a/js/stanford_events_importer.js
+++ b/js/stanford_events_importer.js
@@ -18,10 +18,10 @@
   Drupal.behaviors.stanford_date_timepicker = {
     attach: function (context, settings) {
 
-      // Attach the blur handler to each date field.
+      // Attach the change handler to each date field.
       $.each($('.start-date-wrapper ', context), function(i, v) {
         var timefield = $(v).find('input:eq(1)');
-        timefield.bind('blur.stanford_events_importer', from_time_blur_handler);
+        timefield.bind('change.stanford_events_importer', from_time_change_handler);
       });
 
     }
@@ -33,11 +33,11 @@
 
 
   /**
-   * Blur callback event handler for from time fields.
+   * Change callback event handler for from time fields.
    * Adds functionality to add 1 hour to the 'to' time value in the
    * same field collection as the 'from' time value.
    */
-  var from_time_blur_handler = function(e) {
+  var from_time_change_handler = function(e) {
 
     // First find the show end date checkbox and see if it is checked.
     var showend = $(this)
@@ -67,9 +67,9 @@
     if (typeof to_date_field === undefined) { stanford_events_importer_unset_bind(this); return; }
     if (typeof to_time_field === undefined) { stanford_events_importer_unset_bind(this); return; }
 
-    // Add a one time blur function to the 'to' time field so that when
+    // Add a one time change function to the 'to' time field so that when
     // the user manipulates that time manually we don't eff with it.
-    to_time_field.one('blur', to_time_blur_handler);
+    to_time_field.one('change', to_time_change_handler);
 
     // If the date field is empty populate it.
     if (to_date_field.val().length === 0) {
@@ -101,9 +101,9 @@
   };
 
   /**
-   * An event handler to unbind the to_time_event_handler on blur.
+   * An event handler to unbind the to_time_event_handler on change.
    */
-  var to_time_blur_handler = function(e) {
+  var to_time_change_handler = function(e) {
     // Fields and variable definitions oh my!
     var fields = $(this)
                  .closest('.fieldset-wrapper')
@@ -113,8 +113,8 @@
     // If we can't find the field then we must end our journey.
     if (typeof from_time_field === undefined) { return; }
 
-    // Remove our blur handler.
-    from_time_field.unbind('blur.stanford_events_importer');
+    // Remove our change handler.
+    from_time_field.unbind('change.stanford_events_importer');
   };
 
 
@@ -125,11 +125,11 @@
   // ---------------------------------------------------------------------------
 
   /**
-   * Unbinds the blur event from something that doesnt need it.
-   * @param  {object} element   the element with the blur event on it.
+   * Unbinds the change event from something that doesnt need it.
+   * @param  {object} element   the element with the change event on it.
    */
   function stanford_events_importer_unset_bind(element) {
-    $(element).unbind('blur.stanford_events_importer');
+    $(element).unbind('change.stanford_events_importer');
   }
 
 

--- a/js/stanford_events_importer.js
+++ b/js/stanford_events_importer.js
@@ -1,6 +1,11 @@
 /**
- * Tracks the time field in the date and time settings for changes
- * so that it may autopopulate the 'to' field.
+ * Creates autopopulation functionailty in javascript.
+ * This is only for event node forms.
+ * When a user selects a from time on data_popup fields the to value is
+ * automatically populated with the same date and time +1 hour.
+ *
+ * @author Shea McKinney <sheamck@stanford.edu>
+ *
  */
 
 
@@ -13,6 +18,7 @@
   Drupal.behaviors.stanford_date_timepicker = {
     attach: function (context, settings) {
 
+      // Attach the blur handler to each date field.
       $.each($('.start-date-wrapper ', context), function(i, v) {
         var timefield = $(v).find('input:eq(1)');
         timefield.bind('blur.stanford_events_importer', from_time_blur_handler);
@@ -27,9 +33,9 @@
 
 
   /**
-   * [time_blur_handler description]
-   * @param  {[type]} e [description]
-   * @return {[type]}   [description]
+   * Blur callback event handler for from time fields.
+   * Adds functionality to add 1 hour to the 'to' time value in the
+   * same field collection as the 'from' time value.
    */
   var from_time_blur_handler = function(e) {
 
@@ -47,7 +53,7 @@
     // Fields and variable definitions oh my!
     var fields = $(this)
                  .closest('.fieldset-wrapper')
-                 .find('.end-date-wrapper input');
+                 .find('.end-date-wrapper input:not(.autopop-no-process)');
     var to_date_field   = fields.eq(0);
     var to_time_field   = fields.eq(1);
     var from_date_field = $(this)
@@ -57,11 +63,12 @@
     var from_time_value = $(this).val();
     var php_time_format = $(this).data('timeformat');
 
-
     // If we can't find the fields then we must end our journey.
-    if (typeof to_date_field === undefined) { return; }
-    if (typeof to_time_field === undefined) { return; }
+    if (typeof to_date_field === undefined) { stanford_events_importer_unset_bind(this); return; }
+    if (typeof to_time_field === undefined) { stanford_events_importer_unset_bind(this); return; }
 
+    // Add a one time blur function to the 'to' time field so that when
+    // the user manipulates that time manually we don't eff with it.
     to_time_field.one('blur', to_time_blur_handler);
 
     // If the date field is empty populate it.
@@ -69,22 +76,22 @@
       to_date_field.val(from_date_value);
     }
 
-    // Date conversion needs 24hr format.
+    // Date conversion needs 24hr format. Do some funny parsing.
     var from_time_value_twenty_four = stanford_events_importer_time_to_twenty_four(from_time_value);
 
     // Something went wrong. Die quietly.
-    if(!from_time_value_twenty_four) {
-      return;
-    }
+    if(!from_time_value_twenty_four) { return; }
 
     // Format the new time appropriately.
     var date_object = new Date(from_date_value + " " + from_time_value_twenty_four);
 
     // Something went wrong. Die quietly.
-    if(date_object.toString() == "Invalid Date") {
-      return;
-    }
+    if(date_object.toString() == "Invalid Date") { return; }
 
+    // Add 1 hour to the time.
+    date_object.setHours(date_object.getHours() + 1);
+
+    // Get a properly formatted value based on what the PHP settings are.
     var formatted_time = stanford_events_importer_get_formatted_time(date_object, php_time_format);
 
     // Set the time field to the new date.
@@ -103,9 +110,10 @@
                  .find('.start-date-wrapper input');
     var from_time_field = fields.eq(1);
 
-    // If we can't find the fields then we must end our journey.
+    // If we can't find the field then we must end our journey.
     if (typeof from_time_field === undefined) { return; }
 
+    // Remove our blur handler.
     from_time_field.unbind('blur.stanford_events_importer');
   };
 
@@ -116,7 +124,21 @@
   // Public Functions
   // ---------------------------------------------------------------------------
 
+  /**
+   * Unbinds the blur event from something that doesnt need it.
+   * @param  {object} element   the element with the blur event on it.
+   */
+  function stanford_events_importer_unset_bind(element) {
+    $(element).unbind('blur.stanford_events_importer');
+  }
 
+
+
+  /**
+   * Parse a time string eg: 4:33pm into a 24 hour time eg: 16:33
+   * @param  {string} time a 12 hour time
+   * @return {string} a 24 hour time
+   */
   function stanford_events_importer_time_to_twenty_four(time) {
 
     // Invalid Syntax Provided.
@@ -124,42 +146,52 @@
       return false;
     }
 
+    // Define parts.
     var hours = Number(time.match(/^(\d+)/)[1]);
     var minutes = Number(time.match(/:(\d+)/)[1]);
     var seconds = time.match(/:(\d+)/)[2];
-
     var AMPM = time.match(/(am|pm)/gi);
+
+    // If am/pm is found then look for pm and add 12hrs to the current time.
     if (AMPM instanceof Array) {
       if (AMPM[0] == "pm" || APMPM[0] == "PM") {
         hours = hours + 12;
       }
     }
 
+    // Convert Number to Strings times.
     var sHours = hours.toString();
     var sMinutes = minutes.toString();
+
+    // Javascript and plugins like the preceeding 0s
     if(hours<10) sHours = "0" + sHours;
     if(minutes<10) sMinutes = "0" + sMinutes;
 
+    // Construct formatted var.
     var formatted = sHours + ":" + sMinutes;
+
+    // Add in seconds if seconds are present in the time.
     if(typeof seconds === 'string') {
       formatted += ":" + seconds;
     }
 
+    // whew!
     return formatted;
   }
 
 
   /**
-   * [stanford_events_importer_get_formatted_time description]
-   * @param  {[type]} dateobj    [description]
-   * @param  {[type]} php_format [description]
-   * @return {[type]}            [description]
+   * Parse a time into a format as defined by php.
+   * @param  {object} date_object    [a date object]
+   * @param  {string} php_format [the php string representation of the time
+   * format we want]
+   * @return {String}            [The formatted date string]
    */
   function stanford_events_importer_get_formatted_time(date_object, php_format) {
 
     var formatted = php_format;
 
-    date_object.setHours(date_object.getHours() + 1);
+    // Define date parts as string with preceeding 0s by default.
     var hr_twentyfour = date_object.getHours() < 12 ? "0" + date_object.getHours().toString() : date_object.getHours();
     var hr_twelve = (hr_twentyfour - 12) < 12 ? "0" + (hr_twentyfour - 12) : 12;
     var min = date_object.getMinutes() < 10 ? "0" + date_object.getMinutes().toString() : date_object.getMinutes();
@@ -181,6 +213,7 @@
     // Am/Pm.
     formatted = formatted.replace(/[a]/g, ampm);
     formatted = formatted.replace(/[A]/g, ampm.toUpperCase());
+
     return formatted;
   }
 
@@ -188,31 +221,30 @@
 // Jquery Plugins
 // -----------------------------------------------------------------------------
 
-if(typeof $.fn.highlight !== "function") {
-    /**
-   * A quick yellow highlight that fades out.
-   */
-  $.fn.highlight = function() {
+  if(typeof $.fn.highlight !== "function") {
+      /**
+     * A quick yellow highlight that fades out.
+     */
+    $.fn.highlight = function() {
 
-    $(this).each(function () {
-        var el = $(this);
-        $("<div/>")
-        .width(el.outerWidth())
-        .height(el.outerHeight())
-        .css({
-            "position": "absolute",
-            "left": el.offset().left,
-            "top": el.offset().top,
-            "background-color": "#ffff99",
-            "opacity": ".7",
-            "z-index": "9999999"
-        }).appendTo('body').fadeOut(1000).queue(function () { $(this).remove(); });
-    });
+      $(this).each(function () {
+          var el = $(this);
+          $("<div/>")
+          .width(el.outerWidth())
+          .height(el.outerHeight())
+          .css({
+              "position": "absolute",
+              "left": el.offset().left,
+              "top": el.offset().top,
+              "background-color": "#ffff99",
+              "opacity": ".7",
+              "z-index": "9999999"
+          }).appendTo('body').fadeOut(1000).queue(function () { $(this).remove(); });
+      });
 
-  };
+    };
 
-}
+  }
 
 
 })(jQuery);
-

--- a/js/stanford_events_importer.js
+++ b/js/stanford_events_importer.js
@@ -154,7 +154,7 @@
 
     // If am/pm is found then look for pm and add 12hrs to the current time.
     if (AMPM instanceof Array) {
-      if (AMPM[0] == "pm" || APMPM[0] == "PM") {
+      if (AMPM[0] == "pm" || AMPM[0] == "PM") {
         hours = hours + 12;
       }
     }

--- a/js/stanford_events_importer.js
+++ b/js/stanford_events_importer.js
@@ -15,13 +15,13 @@
   // ---------------------------------------------------------------------------
 
 
-  Drupal.behaviors.stanford_date_timepicker = {
+  Drupal.behaviors.stanford_events_importer = {
     attach: function (context, settings) {
 
-      // Attach the change handler to each date field.
+      // Attach the blur handler to each date field.
       $.each($('.start-date-wrapper ', context), function(i, v) {
         var timefield = $(v).find('input:eq(1)');
-        timefield.bind('change.stanford_events_importer', from_time_change_handler);
+        timefield.bind('blur.stanford_events_importer', from_time_blur_handler);
       });
 
     }
@@ -33,11 +33,11 @@
 
 
   /**
-   * Change callback event handler for from time fields.
+   * Blur callback event handler for from time fields.
    * Adds functionality to add 1 hour to the 'to' time value in the
    * same field collection as the 'from' time value.
    */
-  var from_time_change_handler = function(e) {
+  var from_time_blur_handler = function(e) {
 
     // First find the show end date checkbox and see if it is checked.
     var showend = $(this)
@@ -67,9 +67,9 @@
     if (typeof to_date_field === undefined) { stanford_events_importer_unset_bind(this); return; }
     if (typeof to_time_field === undefined) { stanford_events_importer_unset_bind(this); return; }
 
-    // Add a one time change function to the 'to' time field so that when
+    // Add a one time blur function to the 'to' time field so that when
     // the user manipulates that time manually we don't eff with it.
-    to_time_field.one('change', to_time_change_handler);
+    to_time_field.one('blur', to_time_blur_handler);
 
     // If the date field is empty populate it.
     if (to_date_field.val().length === 0) {
@@ -101,9 +101,9 @@
   };
 
   /**
-   * An event handler to unbind the to_time_event_handler on change.
+   * An event handler to unbind the to_time_event_handler on blur.
    */
-  var to_time_change_handler = function(e) {
+  var to_time_blur_handler = function(e) {
     // Fields and variable definitions oh my!
     var fields = $(this)
                  .closest('.fieldset-wrapper')
@@ -113,8 +113,8 @@
     // If we can't find the field then we must end our journey.
     if (typeof from_time_field === undefined) { return; }
 
-    // Remove our change handler.
-    from_time_field.unbind('change.stanford_events_importer');
+    // Remove our blur handler.
+    from_time_field.unbind('blur.stanford_events_importer');
   };
 
 
@@ -125,11 +125,11 @@
   // ---------------------------------------------------------------------------
 
   /**
-   * Unbinds the change event from something that doesnt need it.
-   * @param  {object} element   the element with the change event on it.
+   * Unbinds the blur event from something that doesnt need it.
+   * @param  {object} element   the element with the blur event on it.
    */
   function stanford_events_importer_unset_bind(element) {
-    $(element).unbind('change.stanford_events_importer');
+    $(element).unbind('blur.stanford_events_importer');
   }
 
 

--- a/stanford_events_importer.module
+++ b/stanford_events_importer.module
@@ -256,6 +256,14 @@ function stanford_events_importer_build_feed_url($form, &$form_state) {
 }
 
 /**
+ * Implements hook_form_alter().
+ */
+function stanford_events_importer_form_stanford_event_node_form_alter(&$form, &$form_state) {
+  drupal_add_js(drupal_get_path('module', 'stanford_events_importer') . '/js/stanford_events_importer.js');
+}
+
+
+/**
  * Fetch the list of categories.
  */
 function stanford_events_importer_get_categories() {

--- a/stanford_events_importer.module
+++ b/stanford_events_importer.module
@@ -403,3 +403,20 @@ function stanford_events_importer_update_cat_org() {
 function stanford_events_importer_cron() {
   stanford_events_importer_update_cat_org();
 }
+
+
+/**
+ * Implements hook date_popup_process_alter()
+ * Alters the time field to include additional formatting data for js to use.
+ */
+function stanford_events_importer_date_popup_process_alter(&$element, &$form_state, $form) {
+
+  // The time field. Already processed.
+  $format = preg_replace('/[^AaigGHhs\:]/', '', $element['#date_format']);
+  // $element['#attributes']['data-timeformat'] = $format;
+  // $element['#wrapper_attributes']['data-timeformat'] = $format;
+  $element['time']['#attributes']['data-timeformat'] = $format;
+
+}
+
+

--- a/stanford_events_importer.module
+++ b/stanford_events_importer.module
@@ -417,6 +417,9 @@ function stanford_events_importer_date_popup_process_alter(&$element, &$form_sta
   // $element['#wrapper_attributes']['data-timeformat'] = $format;
   $element['time']['#attributes']['data-timeformat'] = $format;
 
+  // If there is a value on the to field already then we dont want to autopop.
+  if (!empty($element['#value']['time'])) {
+    $element['time']['#attributes']['class'][] = 'autopop-no-process';
+  }
+
 }
-
-


### PR DESCRIPTION
# READY

New functionality to automatically add a 'to' date value in the node edit form and time on stanford_event node types.
1. Only adds functionality on the event node type
2. Formats the time and date to match field settings
3. Adds change highlight yellow fade
4. Not configurable
5. Adds exactly 1 hour to the time field without manipulating the date.
6. If an end user changes the to time field manually the automatic updating event is removed

This functionality has been added to the event type only. It could possibly be abstracted and tied into the field settings to allow other content types to use this functionality. 
