### PR TITLE
Fixed default to date population so that javascript autopop works

### DIFF
--- a/js/stanford_events_importer.js
+++ b/js/stanford_events_importer.js
@@ -199,8 +199,8 @@
     var ampm = date_object.getHours() < 12 ? "am" : "pm";
     var hr_twentyfour = date_object.getHours() < 10 ? "0" + date_object.getHours().toString() : date_object.getHours().toString();
     var hr_twelve = hr_twentyfour;
-    if (parseInt(hr_twelve, 10) >= 12) { hr_twelve = hr_twentyfour-12; }
-    if (hr_twelve === 0) { hr_twelve = 12; }
+    if (parseInt(hr_twelve, 10) > 12) { hr_twelve = parseInt(hr_twentyfour, 10) - 12; }
+    if (hr_twelve == 0) { hr_twelve = 12; }
     hr_twelve = (hr_twelve < 10) ? "0" + hr_twelve : hr_twelve.toString();
     var min = date_object.getMinutes() < 10 ? "0" + date_object.getMinutes().toString() : date_object.getMinutes();
     var sec = date_object.getSeconds() < 10 ? "0" + date_object.getSeconds().toString() : date_object.getSeconds();

--- a/js/stanford_events_importer.js
+++ b/js/stanford_events_importer.js
@@ -84,7 +84,9 @@
     if(!from_time_value_twenty_four) { return; }
 
     // Format the new time appropriately.
-    var date_object = new Date(from_date_value + " " + from_time_value_twenty_four);
+    // Remove extra formatting
+    var fdv = from_date_value.replace(/\-|\//g, ' ');
+    var date_object = new Date(fdv + " " + from_time_value_twenty_four);
 
     // Something went wrong. Die quietly.
     if(date_object.toString() == "Invalid Date") { return; }

--- a/js/stanford_events_importer.js
+++ b/js/stanford_events_importer.js
@@ -246,7 +246,7 @@
       .css({
           "position": "absolute",
           "left": 0,
-          "top": 20,
+          "top": 24,
           "background-color": "#ffff99",
           "opacity": ".7",
           "z-index": "0"

--- a/stanford_events_importer.features.field.inc
+++ b/stanford_events_importer.features.field.inc
@@ -437,7 +437,7 @@ function stanford_events_importer_field_default_fields() {
       'required' => 0,
       'settings' => array(
         'default_value' => 'now',
-        'default_value2' => 'same',
+        'default_value2' => 'blank',
         'default_value_code' => '',
         'default_value_code2' => '',
         'user_register_form' => FALSE,

--- a/stanford_events_importer.features.field.inc
+++ b/stanford_events_importer.features.field.inc
@@ -447,7 +447,7 @@ function stanford_events_importer_field_default_fields() {
         'module' => 'date',
         'settings' => array(
           'display_all_day' => 1,
-          'increment' => 1,
+          'increment' => 5,
           'input_format' => 'custom',
           'input_format_custom' => 'Y-m-d g:i:sA',
           'label_position' => 'above',


### PR DESCRIPTION
# Ready

When a default value is provided the javascript autopopulation does not fire. 

This patch fixes that. 
