### PR TITLE
SITES-779 Corrected hook help

### DIFF
--- a/stanford_events_importer.module
+++ b/stanford_events_importer.module
@@ -22,7 +22,7 @@ function stanford_events_importer_help($path, $arg) {
   );
 
   switch ($path) {
-    case'admin/help':
+    case'admin/help#stanford_events_importer':
       $output = '<h2>' . t('To Use') . '</h2>';
       $output .= '<ol><li>' . t('Enable the module and all dependencies') . '</li>';
       $output .= '<li>' . t('Go to !permissions and give selected roles the following permissions:', $links);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed hook_help to display the help text only  when user clicks on the module.

# Needed By (Date)
- whenever

# Urgency
- low

# Steps to Test

1. checkout this branch
1. clear cache
1. view admin/help
1. verify events help doesnt display unless you click on the module name.

# Affected Projects or Products
- All jumpstart products.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)